### PR TITLE
Fix two bugs; Add new pre-trained model; Add new results

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 PyTorch implementation of the [paper](https://arxiv.org/abs/2210.12316)
 > Yupeng Hou, Zhankui He, Julian McAuley, Wayne Xin Zhao. Learning Vector-Quantized Item Representation for Transferable Sequential Recommenders. TheWebConf 2023.
 
+---
+
+*Updates*:
+
+* [Mar. 27, 2023] We fixed two minor bugs in pre-training (Raised by [UniSRec#9](https://github.com/RUCAIBox/UniSRec/pull/9) and an email from Xingyu Lu, respectively. Thanks a lot!!). We pre-trained VQ-Rec again and the new pre-trained model has been uploaded as `pretrained/VQRec-FHCKM-300-20230315.pth`. We also evaluated the new pre-trained model on six downstream datasets. Generally, the new pre-trained model performs better. Please refer to [Results](#results) for more details.
+
 ## Overview
 
 Recently, the generality of natural language text has been leveraged to develop transferable recommender systems. The basic idea is to employ pre-trained language model~(PLM) to encode item text into item representations. Despite the promising transferability, the binding between item text and item representations might be "*too tight*", leading to potential problems such as over-emphasizing the effect of text features and exaggerating the negative impact of domain gap. To address this issue, this paper proposes **VQ-Rec**, a novel approach to learning <ins>V</ins>ector-<ins>Q</ins>uantized item representations for transferable sequential <ins>Rec</ins>ommender. The major novelty of our approach lies in the new item representation scheme: it first maps item text into a vector of discrete indices (called *item code*), and then employs these indices to lookup the code embedding table for deriving item representations. Such a scheme can be denoted as "*text* ==> *code* ==> *representation*". Based on this representation scheme, we further propose an enhanced contrastive pre-training approach, using semi-synthetic and mixed-domain code representations as hard negatives. Furthermore, we design a new cross-domain fine-tuning method based on a differentiable permutation-based network.
@@ -25,7 +31,9 @@ We use the processed datasets from [UniSRec](https://github.com/RUCAIBox/UniSRec
 
 ## Pre-trained Model and Item Codes
 
-The pre-trained model is located at `pretrained/VQRec-FHCKM-300.pth`.
+The original pre-trained model is located at `pretrained/VQRec-FHCKM-300.pth`. This checkpoint was created in Oct. 2022 and used for all our experiments reported in our paper.
+
+We also uploaded a new pre-trained model at `pretrained/VQRec-FHCKM-300-20230315.pth`. We fixed two bugs in our pre-training scripts and created this checkpoint in Mar. 2023. Associated results can be found at [Results](#results)
 
 The pre-trained item codes (both on pre-training and downstreaem datasets) are located at `dataset/`.
 
@@ -84,6 +92,36 @@ Pre-train on multiple GPUs:
 
 ```bash
 CUDA_VISIBLE_DEVICES=0,1,2,3 python ddp_pretrain.py
+```
+
+## Results (Updated March 27, 2023)
+
+We fixed two bugs in March 2023 and re-trained a new version of pre-trained VQ-Rec model as `pretrained/VQRec-FHCKM-300-20230315.pth`. The fine-tuned results on six downstream datasets are presented here. Improved metrics (compared to the results in our paper) are denoted as bold.
+
+|Dataset|Model|R@10|N@10|R@50|N@50|
+|---|---|---|---|---|---|
+|Scientific|VQ-Rec|0.1211|0.0643|0.2369|0.0897|
+|Scientific|VQ-Rec (0315)|**0.1238**|**0.0645**|**0.2409**|**0.0901**|
+|Pantry|VQ-Rec|0.0660|0.0293|0.1753|0.0527|
+|Pantry|VQ-Rec (0315)|0.0656|0.0291|**0.1761**|**0.0531**|
+|Instruments|VQ-Rec|0.1222|0.0758|0.2343|0.1002|
+|Instruments|VQ-Rec (0315)|**0.1229**|**0.0775**|0.2341|**0.1015**|
+|Arts|VQ-Rec|0.1189|0.0703|0.2249|0.0935|
+|Arts|VQ-Rec (0315)|**0.1196**|**0.0709**|**0.2266**|**0.0942**|
+|Office|VQ-Rec|0.1236|0.0814|0.1957|0.0972|
+|Office|VQ-Rec (0315)|**0.1240**|**0.0823**|0.1952|**0.0978**|
+|Online Retail|VQ-Rec|0.1557|0.0730|0.3994|0.1263|
+|Online Retail|VQ-Rec (0315)|**0.1559**|0.0704|**0.4009**|0.1240|
+
+These results can be reproduced by running the following scripts.
+
+```
+python finetune.py -d Scientific -p pretrained/VQRec-FHCKM-300-20230315.pth -f fix_enc --learning_rate=0.003
+python finetune.py -d Pantry -p pretrained/VQRec-FHCKM-300-20230315.pth -f fix_enc --learning_rate=0.003
+python finetune.py -d Instruments -p pretrained/VQRec-FHCKM-300-20230315.pth -f fix_enc --learning_rate=0.003
+python finetune.py -d Arts -p pretrained/VQRec-FHCKM-300-20230315.pth -f fix_enc --learning_rate=0.001
+python finetune.py -d Office -p pretrained/VQRec-FHCKM-300-20230315.pth -f fix_enc --learning_rate=0.003
+python finetune.py -d OR -p pretrained/VQRec-FHCKM-300-20230315.pth -f fix_enc --learning_rate=0.003
 ```
 
 ## Acknowledgement

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Pre-train on multiple GPUs:
 CUDA_VISIBLE_DEVICES=0,1,2,3 python ddp_pretrain.py
 ```
 
-## Results (Updated March 27, 2023)
+## Results
 
 We fixed two bugs in March 2023 and re-trained a new version of pre-trained VQ-Rec model as `pretrained/VQRec-FHCKM-300-20230315.pth`. The fine-tuned results on six downstream datasets are presented here. Improved metrics (compared to the results in our paper) are denoted as bold.
 

--- a/vqrec.py
+++ b/vqrec.py
@@ -163,7 +163,6 @@ class VQRec(SequentialRecommender):
         
         mask = torch.bernoulli(torch.full_like(item_index, self.fake_idx_ratio, dtype=torch.float))
         fake_item_idx = torch.where(mask > 0, rand_idx, item_index)
-        fake_item_idx[0,:] = 0
         return self.pq_code_embedding(fake_item_idx).mean(dim=-2)
 
     def seq_item_contrastive_task(self, seq_output, same_pos_id, interaction):

--- a/vqrec.py
+++ b/vqrec.py
@@ -180,7 +180,7 @@ class VQRec(SequentialRecommender):
 
         neg_logits = torch.matmul(seq_output, pos_items_emb.transpose(0, 1)) / self.temperature
         neg_logits = torch.where(same_pos_id, torch.tensor([0], dtype=torch.float, device=same_pos_id.device), neg_logits)
-        neg_logits = torch.exp(neg_logits).sum(dim=1)
+        neg_logits = torch.exp(neg_logits).sum(dim=1).reshape(-1, 1)
 
         fake_item_emb = self.generate_fake_neg_item_emb(pos_pq_code)
         fake_item_emb = F.normalize(fake_item_emb, dim=-1)


### PR DESCRIPTION
Fix two bugs:
1. Raised by [UniSRec#9](https://github.com/RUCAIBox/UniSRec/pull/9). One tensor's shape is wrong of calculating contrastive loss, which may introduce noise.
2. Raised by Xingyu Lu from an email. Original implementation introduces unnecessary mask.

After fixing bugs, we pre-train VQ-Rec again and report its results on six downstream datasets.